### PR TITLE
Docs - Fixed input action C# issue

### DIFF
--- a/tutorials/inputs/inputevent.rst
+++ b/tutorials/inputs/inputevent.rst
@@ -234,8 +234,8 @@ The Input singleton has a method for this:
 
     var ev = new InputEventAction();
     // Set as ui_left, pressed.
-    ev.SetAction("ui_left");
-    ev.SetPressed(true);
+    ev.Action = "ui_left";
+    ev.Pressed = true;
     // Feedback.
     Input.ParseInputEvent(ev);
 


### PR DESCRIPTION
The `SetAction` and `SetPressed` are internal methods and can't be invoked directly outside of that assembly. 

![InputEventAction.cs methods](https://github.com/user-attachments/assets/6d199ed0-17d5-4a25-8794-829cec45f6cc)

Instead, the `Action` and `Pressed` property setters can be used to invoke them instead.

![InputEventAction.cs setters](https://github.com/user-attachments/assets/3841052d-0770-4f06-9ce1-fceb346b35aa)
